### PR TITLE
fix(clob): use consistent 6 decimal scaling for order amounts

### DIFF
--- a/packages/clob/src/api/order.test.ts
+++ b/packages/clob/src/api/order.test.ts
@@ -208,9 +208,9 @@ describe("OrderApi createOrder behavior", () => {
     } as unknown as BaseClient;
   };
 
-  const createMockMarketApi = () => {
+  const createMockMarketApi = (tickSize = "0.01") => {
     return {
-      getTickSize: mock(async () => "0.01"),
+      getTickSize: mock(async () => tickSize),
       getFeeRateBps: mock(async () => 0),
     } as unknown as MarketApi;
   };
@@ -288,6 +288,93 @@ describe("OrderApi createOrder behavior", () => {
     });
 
     expect(order.signatureType).toBe("poly-proxy");
+  });
+
+  test("should use consistent 6 decimal scaling for BUY order amounts", async () => {
+    const mockClient = createMockClient();
+    // tickSize "0.001" means 3 decimals for price
+    const mockMarketApi = createMockMarketApi("0.001");
+    const api = new OrderApi(mockClient, mockMarketApi);
+
+    // price=0.545, size=1.83
+    // shares = 1.83 (rounded to 2 decimals)
+    // cost = 1.83 * 0.545 = 0.99735 (rounded to 5 decimals for tick=3 + size=2)
+    // Both should use 10^6 scaling
+    // sharesRaw = 1.83 * 10^6 = 1830000
+    // costRaw = 0.99735 * 10^6 = 997350
+    const order = await api.createOrder({
+      tokenId,
+      price: 0.545,
+      size: 1.83,
+      side: "BUY",
+      expiration: 0,
+      taker: "anyone",
+    });
+
+    // BUY: maker gives USDC (cost), taker gives shares
+    expect(order.makerAmount).toBe("997350");
+    expect(order.takerAmount).toBe("1830000");
+
+    // Verify price calculation: makerAmount / takerAmount = 0.545...
+    const impliedPrice =
+      parseInt(order.makerAmount, 10) / parseInt(order.takerAmount, 10);
+    expect(impliedPrice).toBeCloseTo(0.545, 3);
+  });
+
+  test("should use consistent 6 decimal scaling for SELL order amounts", async () => {
+    const mockClient = createMockClient();
+    const mockMarketApi = createMockMarketApi("0.001");
+    const api = new OrderApi(mockClient, mockMarketApi);
+
+    const order = await api.createOrder({
+      tokenId,
+      price: 0.545,
+      size: 1.83,
+      side: "SELL",
+      expiration: 0,
+      taker: "anyone",
+    });
+
+    // SELL: maker gives shares, taker gives USDC (cost)
+    expect(order.makerAmount).toBe("1830000");
+    expect(order.takerAmount).toBe("997350");
+
+    // Verify price calculation: takerAmount / makerAmount = 0.545...
+    const impliedPrice =
+      parseInt(order.takerAmount, 10) / parseInt(order.makerAmount, 10);
+    expect(impliedPrice).toBeCloseTo(0.545, 3);
+  });
+
+  test("should produce valid price (between 0 and 1) from order amounts", async () => {
+    const mockClient = createMockClient();
+    const mockMarketApi = createMockMarketApi("0.01");
+    const api = new OrderApi(mockClient, mockMarketApi);
+
+    // Test various prices to ensure they all produce valid implied prices
+    const testCases = [
+      { price: 0.1, size: 5.0 },
+      { price: 0.5, size: 10.0 },
+      { price: 0.99, size: 2.5 },
+      { price: 0.01, size: 100.0 },
+    ];
+
+    for (const { price, size } of testCases) {
+      const order = await api.createOrder({
+        tokenId,
+        price,
+        size,
+        side: "BUY",
+        expiration: 0,
+        taker: "anyone",
+      });
+
+      // For BUY orders: implied price = makerAmount / takerAmount
+      const impliedPrice =
+        parseInt(order.makerAmount, 10) / parseInt(order.takerAmount, 10);
+      expect(impliedPrice).toBeGreaterThan(0);
+      expect(impliedPrice).toBeLessThan(1);
+      expect(impliedPrice).toBeCloseTo(price, 2);
+    }
   });
 });
 

--- a/packages/clob/src/api/order.ts
+++ b/packages/clob/src/api/order.ts
@@ -246,15 +246,17 @@ export class OrderApi {
     const tickDecimals = tickSize.split(".")[1]?.length || 0;
     const sizeDecimals = 2;
     const amountDecimals = tickDecimals + sizeDecimals;
+    // Polymarket uses 6 decimals for both maker and taker amounts (USDC precision)
+    const tokenDecimals = 6;
 
     const roundedPrice = roundTo(price, tickDecimals);
     const shares = roundTo(size, sizeDecimals);
     const cost = roundTo(shares * roundedPrice, amountDecimals);
 
-    // Convert to raw integers (no decimals) for smart contract
-    // e.g., "2.00" with 6 decimals -> "2000000"
-    const sharesRaw = Math.floor(shares * 10 ** sizeDecimals).toString();
-    const costRaw = Math.floor(cost * 10 ** amountDecimals).toString();
+    // Convert to raw integers using 6 decimals for both amounts
+    // This ensures price = makerAmount / takerAmount produces a valid value
+    const sharesRaw = Math.floor(shares * 10 ** tokenDecimals).toString();
+    const costRaw = Math.floor(cost * 10 ** tokenDecimals).toString();
 
     if (side === "BUY") {
       // BUY: maker gives USDC, gets shares


### PR DESCRIPTION
## Summary

- Fixed `calculateOrderAmounts` to use consistent 6 decimal scaling (10^6) for both maker and taker amounts
- Previously, shares used 2 decimals (10^2) while cost used 5 decimals (10^5), causing invalid price calculations
- The Polymarket API calculates price as `makerAmount / takerAmount`, which produced values > 1 with the inconsistent scaling

## Problem

| Value | Expected | Actual (Before Fix) |
|-------|----------|---------------------|
| makerAmount | 99735 | 99735 |
| takerAmount | 1830000 | 183 |
| Implied price | 0.545 | **545** ❌ |

API rejected with: `"invalid price, price must be greater than 0 and less than 1"`

## Solution

Changed both amounts to use 6 decimals (USDC precision), matching the [official Polymarket SDK](https://github.com/Polymarket/py-clob-client).

## Test plan

- [x] Added unit tests verifying consistent decimal scaling for BUY orders
- [x] Added unit tests verifying consistent decimal scaling for SELL orders
- [x] Added unit tests verifying implied price is valid (0 < price < 1)
- [x] All 80 tests pass
- [x] Lint passes

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)